### PR TITLE
Put some space between the input and output of \e (Evaluate)

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -119,7 +119,7 @@ function! IdrisEval()
      let expr = input ("Expression: ")
      let fn = "idris --client '" . expr . "'"
      let result = system(fn)
-     echo result
+     echo " = " . result
   endif
   echo ""
 endfunction


### PR DESCRIPTION
So you get `5+5 = 10 : Integer` instead of `5+510 : Integer`
