### PR TITLE
fix idris mode in MacVim

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -67,7 +67,7 @@ function! IWrite(str)
 endfunction
 
 function! IdrisReload(q)
-  let file = expand("%")
+  let file = expand("%:p")
   let tc = system("idris --client :l " . file)
   if (! (tc is ""))
     call IWrite(tc)


### PR DESCRIPTION
fixes a problem in MacVim where idris mode doesn't work if idris and MacVim are in different working directorys
