### PR TITLE
Fixes issues with non-atomic writes to IBC files from REPL

### DIFF
--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -27,7 +27,7 @@ endif
 function! SyntaxCheckers_idris_idris_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'exe': 'idris',
-        \ 'args': '--check '. g:syntastic_idris_options,
+        \ 'args': '--client :l'. g:syntastic_idris_options,
         \ 'filetype': 'idris',
         \ 'subchecker': 'idris' })
 


### PR DESCRIPTION
While vim is interacting with the Idris REPL over sockets
and we call 'idris --check' we end up with inconsistent IBC
files. Lets us instead call 'idris --client :l' as it is both
consistent with REPL interactive workflow and faster.

Signed-off-by: Edward O'Callaghan eocallaghan@alterapraxis.com
