### PR TITLE
Add commentstring setting.

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -10,6 +10,7 @@ setlocal shiftwidth=2
 setlocal tabstop=2
 setlocal expandtab
 setlocal comments=s1:{-,mb:-,ex:-},:\|\|\|,:--
+setlocal commentstring=--%s
 
 let idris_response = 0
 let b:did_ftplugin = 1


### PR DESCRIPTION
The commentstring setting is used in plugins like Tim Pope's
"commentary" plugin.  commentstring defaults to "/*", which is not
usable by idris.  This commit changes it to "--".
