### PR TITLE
Fix Syntastic integration

### DIFF
--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -27,7 +27,8 @@ endif
 function! SyntaxCheckers_idris_idris_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'exe': 'idris',
-        \ 'args': '--client :l'. g:syntastic_idris_options,
+        \ 'args': "--client ':l". g:syntastic_idris_options,
+        \ 'post_args': "'",
         \ 'filetype': 'idris',
         \ 'subchecker': 'idris' })
 

--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -34,8 +34,9 @@ function! SyntaxCheckers_idris_idris_GetLocList() dict
 
     let errorformat =
         \ '"%f" (line %l\, column %c\):,' .
-        \ '%f\:%l\:%m,' .
-        \ 'user error (%f\:%l\:%m\)'
+        \ 'user error (%f\:%l\:%m\),' .
+        \ '%E%f\:%l\:%c\:,' .
+        \ '%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
Fixes Syntastic integration; previously, Syntastic wasn't displaying errors with the latest versions of nvim, idris, and Syntastic.