### PR TITLE
Ensure default mappings don't echo command

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -291,22 +291,22 @@ function! IdrisEval()
   endif
 endfunction
 
-nnoremap <LocalLeader>t :call IdrisShowType()<ENTER>
-nnoremap <LocalLeader>r :call IdrisReload(0)<ENTER>
-nnoremap <LocalLeader>c :call IdrisCaseSplit()<ENTER>
-nnoremap <LocalLeader>d 0:call search(":")<ENTER>b:call IdrisAddClause(0)<ENTER>w
-nnoremap <LocalLeader>b 0:call IdrisAddClause(0)<ENTER>
-nnoremap <LocalLeader>m :call IdrisAddMissing()<ENTER>
-nnoremap <LocalLeader>md 0:call search(":")<ENTER>b:call IdrisAddClause(1)<ENTER>w
-nnoremap <LocalLeader>f :call IdrisRefine()<ENTER>
-nnoremap <LocalLeader>o :call IdrisProofSearch(0)<ENTER>
-nnoremap <LocalLeader>p :call IdrisProofSearch(1)<ENTER>
-nnoremap <LocalLeader>l :call IdrisMakeLemma()<ENTER>
-nnoremap <LocalLeader>e :call IdrisEval()<ENTER>
-nnoremap <LocalLeader>w 0:call IdrisMakeWith()<ENTER>
-nnoremap <LocalLeader>mc :call IdrisMakeCase()<ENTER>
-nnoremap <LocalLeader>i 0:call IdrisResponseWin()<ENTER>
-nnoremap <LocalLeader>h :call IdrisShowDoc()<ENTER>
+nnoremap <silent> <LocalLeader>t :call IdrisShowType()<ENTER>
+nnoremap <silent> <LocalLeader>r :call IdrisReload(0)<ENTER>
+nnoremap <silent> <LocalLeader>c :call IdrisCaseSplit()<ENTER>
+nnoremap <silent> <LocalLeader>d 0:call search(":")<ENTER>b:call IdrisAddClause(0)<ENTER>w
+nnoremap <silent> <LocalLeader>b 0:call IdrisAddClause(0)<ENTER>
+nnoremap <silent> <LocalLeader>m :call IdrisAddMissing()<ENTER>
+nnoremap <silent> <LocalLeader>md 0:call search(":")<ENTER>b:call IdrisAddClause(1)<ENTER>w
+nnoremap <silent> <LocalLeader>f :call IdrisRefine()<ENTER>
+nnoremap <silent> <LocalLeader>o :call IdrisProofSearch(0)<ENTER>
+nnoremap <silent> <LocalLeader>p :call IdrisProofSearch(1)<ENTER>
+nnoremap <silent> <LocalLeader>l :call IdrisMakeLemma()<ENTER>
+nnoremap <silent> <LocalLeader>e :call IdrisEval()<ENTER>
+nnoremap <silent> <LocalLeader>w 0:call IdrisMakeWith()<ENTER>
+nnoremap <silent> <LocalLeader>mc :call IdrisMakeCase()<ENTER>
+nnoremap <silent> <LocalLeader>i 0:call IdrisResponseWin()<ENTER>
+nnoremap <silent> <LocalLeader>h :call IdrisShowDoc()<ENTER>
 
 menu Idris.Reload <LocalLeader>r
 menu Idris.Show\ Type <LocalLeader>t


### PR DESCRIPTION
Without `<silent>` the mappings display the command being executed in the command-line. For example using `<localleader>i` with a response window already open displays `:call IdrisResponseWin()` in the command-line.