### PR TITLE
Update errorformat to catch errors better

### DIFF
--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -36,7 +36,8 @@ function! SyntaxCheckers_idris_idris_GetLocList() dict
         \ 'user error (%f\:%l\:%m\),' .
         \ '%E%f:%l:%c: error: %m,' .
         \ '%W%f:%l:%c: warning: %m,' .
-        \ '%C%m'
+        \ '%C%m,' .
+        \ '%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -23,15 +23,6 @@ if !exists("g:syntastic_idris_options")
     let g:syntastic_idris_options = " "
 endif
 
-function! FixLeadingComments(errors) abort
-    echo a:errors
-    return map(copy(a:errors), 'substitute(v:val, "\\v^\\|\\| ", "", "")')
-endfunction
-
-function! TestPost(errors) abort
-    echo a:errors
-endfunction
-
 function! SyntaxCheckers_idris_idris_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'exe': 'idris',

--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -23,6 +23,14 @@ if !exists("g:syntastic_idris_options")
     let g:syntastic_idris_options = " "
 endif
 
+function! FixLeadingComments(errors) abort
+    echo a:errors
+    return map(copy(a:errors), 'substitute(v:val, "\\v^\\|\\| ", "", "")')
+endfunction
+
+function! TestPost(errors) abort
+    echo a:errors
+endfunction
 
 function! SyntaxCheckers_idris_idris_GetLocList() dict
     let makeprg = self.makeprgBuild({
@@ -35,12 +43,14 @@ function! SyntaxCheckers_idris_idris_GetLocList() dict
     let errorformat =
         \ '"%f" (line %l\, column %c\):,' .
         \ 'user error (%f\:%l\:%m\),' .
-        \ '%E%f\:%l\:%c\:,' .
-        \ '%m'
+        \ '%E%f:%l:%c: error: %m,' .
+        \ '%W%f:%l:%c: warning: %m,' .
+        \ '%C%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
-        \ 'errorformat': errorformat })
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['compressWhitespace'] })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
The idris syntastic checker did a rather poor job at finding the line number of specific error messages. I improved it but I may not have fixed every possible error message.

Example error message from syntactic quick fix window:

Before:
```
|| ./dep_fun.idr:16:7: error: expected: "with",
||     argument expression,
||     constraint argument,
||     function right hand side,
||     with pattern
|| sum'' {S k} x = \y => sum'' k (x + y)
||       ^
```

After:
```
dep_fun.idr|16 col 7 error| expected: "with", argument expression, constraint argument, function right hand side, with pattern sum'' {S k} x = \y => sum'' k (x + y) ^
```

I haven't been able to exclude the code line from the error message which it arguably should be. Additional this change makes syntactic correctly correctly recognize the line / column number where the error occurred.