### PR TITLE
Add an additional intermediate catchall

### DIFF
--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -36,6 +36,7 @@ function! SyntaxCheckers_idris_idris_GetLocList() dict
         \ 'user error (%f\:%l\:%m\),' .
         \ '%E%f:%l:%c: error: %m,' .
         \ '%W%f:%l:%c: warning: %m,' .
+        \ '%E%f:%l:%c:%m,' .
         \ '%C%m,' .
         \ '%m'
 

--- a/syntax_checkers/idris/idris.vim
+++ b/syntax_checkers/idris/idris.vim
@@ -35,8 +35,11 @@ function! SyntaxCheckers_idris_idris_GetLocList() dict
         \ '"%f" (line %l\, column %c\):,' .
         \ 'user error (%f\:%l\:%m\),' .
         \ '%E%f:%l:%c: error: %m,' .
+        \ '%E%f:%l:%c-%*[0-9]: error: %m,' .
         \ '%W%f:%l:%c: warning: %m,' .
+        \ '%W%f:%l:%c-%*[0-9]: warning: %m,' .
         \ '%E%f:%l:%c:%m,' .
+        \ '%E%f:%l:%c-%*[0-9]:%m,' .
         \ '%C%m,' .
         \ '%m'
 


### PR DESCRIPTION
Some errors which had identifiable line numbers were not getting caught by the error format. This patch fixes these cases (or at least some of them).