### PR TITLE
Ignore ibc files for Idris

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -11,6 +11,7 @@ setlocal tabstop=2
 setlocal expandtab
 setlocal comments=s1:{-,mb:-,ex:-},:\|\|\|,:--
 setlocal commentstring=--%s
+setlocal wildignore+=*.ibc
 
 let idris_response = 0
 let b:did_ftplugin = 1


### PR DESCRIPTION
I've accidentally opened `.ibc` files using `:new` and `:vnew` too many times - this change prevents wildmenu from displaying them.