### PR TITLE
feat: add '?' to iskeyword so that a '?hole' will be treated as singl…

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -11,6 +11,7 @@ setlocal tabstop=2
 setlocal expandtab
 setlocal comments=s1:{-,mb:-,ex:-},:\|\|\|,:--
 setlocal commentstring=--%s
+setlocal iskeyword+=?
 
 let idris_response = 0
 let b:did_ftplugin = 1


### PR DESCRIPTION
This will tell Vim to treat the '?' as part of a word, so that when you press `ciw` or other text-object-related-commands in Vim, a hole with the '?' together will be treated as a single word.