### PR TITLE
Apply type query fixes to more commands.

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -19,6 +19,18 @@ setlocal wildignore+=*.ibc
 let idris_response = 0
 let b:did_ftplugin = 1
 
+" Text near cursor position that needs to be passed to a command.
+" Refinment of `expand(<cword>)` to accomodate differences between
+" a (n)vim word and what Idris requires.
+function! s:currentQueryObject()
+  let word = expand("<cword>")
+  if word =~ '^?'
+    " Cut off '?' that introduces a hole identifier.
+    let word = strpart(word, 1)
+  endif
+  return word
+endfunction
+
 function! s:IdrisCommand(...)
   let idriscmd = shellescape(join(a:000))
   return system("idris --client " . idriscmd)
@@ -105,11 +117,7 @@ endfunction
 
 function! IdrisShowType()
   w
-  let word = expand("<cword>")
-  if word =~ '^?'
-    " Cut off '?' that introduces a hole identifier.
-    let word = strpart(word, 1)
-  endif
+  let word = s:currentQueryObject()
   let cline = line(".")
   let tc = IdrisReloadToLine(cline)
   if (! (tc is ""))
@@ -132,7 +140,7 @@ function! IdrisProofSearch(hint)
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = s:currentQueryObject()
   let tc = IdrisReload(1)
 
   if (a:hint==0)
@@ -156,7 +164,7 @@ function! IdrisMakeLemma()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = s:currentQueryObject()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -230,7 +238,7 @@ function! IdrisMakeWith()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = s:currentQueryObject()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -249,7 +257,7 @@ function! IdrisMakeCase()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = s:currentQueryObject()
   let tc = IdrisReload(1)
 
   if (tc is "")


### PR DESCRIPTION
Damage from a8f9fad was actually larger than issue #69.  This recovers from more of the fallout, though I'm not sure all of it.