### PR TITLE
Fix hole-querying for remaining commands.

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -38,6 +38,15 @@ function! IdrisFold(lineNum)
   return IdrisDocFold(a:lineNum)
 endfunction
 
+function! IdrisGetWord()
+  let word = expand("<cword>")
+  if word =~ '^?'
+    " Cut off '?' that introduces a hole identifier.
+    let word = strpart(word, 1)
+  endif
+  return word
+endfunction
+
 setlocal foldmethod=expr
 setlocal foldexpr=IdrisFold(v:lnum)
 
@@ -105,11 +114,7 @@ endfunction
 
 function! IdrisShowType()
   w
-  let word = expand("<cword>")
-  if word =~ '^?'
-    " Cut off '?' that introduces a hole identifier.
-    let word = strpart(word, 1)
-  endif
+  let word = IdrisGetWord()
   let cline = line(".")
   let tc = IdrisReloadToLine(cline)
   if (! (tc is ""))
@@ -123,7 +128,7 @@ endfunction
 
 function! IdrisShowDoc()
   w
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let ty = s:IdrisCommand(":doc", word)
   call IWrite(ty)
 endfunction
@@ -132,7 +137,7 @@ function! IdrisProofSearch(hint)
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   if (a:hint==0)
@@ -156,7 +161,7 @@ function! IdrisMakeLemma()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -175,7 +180,7 @@ function! IdrisRefine()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   let name = input ("Name: ")
@@ -195,7 +200,7 @@ function! IdrisAddMissing()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -212,7 +217,7 @@ endfunction
 function! IdrisCaseSplit()
   let view = winsaveview()
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReloadToLine(cline)
 
   if (tc is "")
@@ -230,7 +235,7 @@ function! IdrisMakeWith()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -249,7 +254,7 @@ function! IdrisMakeCase()
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReload(1)
 
   if (tc is "")
@@ -268,7 +273,7 @@ function! IdrisAddClause(proof)
   let view = winsaveview()
   w
   let cline = line(".")
-  let word = expand("<cword>")
+  let word = IdrisGetWord()
   let tc = IdrisReloadToLine(cline)
 
   if (tc is "")


### PR DESCRIPTION
This lets holes for be recognized appropriately for creation of lemmas. This was broken in
https://github.com/idris-hackers/idris-vim/pull/68
and partially fixed in:
https://github.com/idris-hackers/idris-vim/pull/71

## How was this tested?

I manually tested:
- [X] Type of hole
- [X] Doc of type
- [X] Proof search (`\o`)
- [X] Case split
- [X] Make lemma
- [X] Add missing
- [X] Make Case
- [X] Make With

I didn't test the remaining use cases, but it doesn't appear that Idris typically expects the hole name to include the preceding ?
