### PR TITLE
Keep cursor position when updating response buffer

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -79,11 +79,13 @@ endfunction
 
 function! IWrite(str)
   if (bufexists("idris-response"))
+    let save_cursor = getcurpos()
     b idris-response
     %delete
     let resp = split(a:str, '\n')
     call append(1, resp)
     b #
+    call setpos('.', save_cursor)
   else
     echo a:str
   endif


### PR DESCRIPTION
Closes #35 

It's possible that this is only needed for neovim, but it works just fine with plain Vim as well.

It's the switching of buffers that sends the cursor to column zero.