### PR TITLE
feat: syntax for verbatim string, and special char

### DIFF
--- a/syntax/idris.vim
+++ b/syntax/idris.vim
@@ -93,4 +93,7 @@ highlight def link idrisChar String
 highlight def link idrisBacktick Operator
 highlight def link hsSpecialChar SpecialChar
 
+syn sync ccomment idrisDocComment,idrisLineComment,idrisBlockComment minlines=100
+"syn sync fromstart
+
 let b:current_syntax = "idris"

--- a/syntax/idris.vim
+++ b/syntax/idris.vim
@@ -45,7 +45,12 @@ syn match idrisDirective "%\(access\|assert_total\|default\|elim\|error_reverse\
 syn keyword idrisDSL lambda variable index_first index_next
 syn match idrisChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
 syn match idrisBacktick "`[A-Za-z][A-Za-z0-9_']*`"
-syn region idrisString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
+
+syn region idrisString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell,hsSpecialChar
+syn region idrisVerbatimString start=/"""/ end=/"""/ contains=@Spell fold
+syn match hsSpecialChar contained "\\\([0-9]\+\|o[0-7]\+\|x[0-9a-fA-F]\+\|[\"\\'&\\abfnrtv]\|^[A-Z^_\[\\\]]\)"
+syn match hsSpecialChar contained "\\\(NUL\|SOH\|STX\|ETX\|EOT\|ENQ\|ACK\|BEL\|BS\|HT\|LF\|VT\|FF\|CR\|SO\|SI\|DLE\|DC1\|DC2\|DC3\|DC4\|NAK\|SYN\|ETB\|CAN\|EM\|SUB\|ESC\|FS\|GS\|RS\|US\|SP\|DEL\)"
+
 syn region idrisBlockComment start="{-" end="-}" contains=idrisBlockComment,idrisTodo,@Spell
 syn region idrisProofBlock start="\(default\s\+\)\?\(proof\|tactics\) *{" end="}" contains=idrisTactic
 syn match idrisIdentifier "[a-zA-Z][a-zA-z0-9_']*" contained
@@ -83,7 +88,9 @@ highlight def link idrisBlockComment Comment
 highlight def link idrisTodo Todo
 highlight def link idrisMetaVar Macro
 highlight def link idrisString String
+highlight def link idrisVerbatimString String
 highlight def link idrisChar String
 highlight def link idrisBacktick Operator
+highlight def link hsSpecialChar SpecialChar
 
 let b:current_syntax = "idris"


### PR DESCRIPTION
1. add syntax support for verbatim string, which is a new syntax feature from [idris 1.2.0](https://www.idris-lang.org/idris-1-2-0-released/)
2. add syntax support for special chars. I checked the [source code of idris](https://github.com/idris-lang/Idris-dev/blob/57b64a7f691ef251cb5a521c171361874cc49136/src/Idris/Parser/Helpers.hs#L96) for the syntax definition about string literal, and it point to [here](https://hackage.haskell.org/package/megaparsec-6.4.0/docs/src/Text-Megaparsec-Char-Lexer.html#charLiteral), and there is some document like that: `The literal character is parsed according to the grammar rules defined in the Haskell report.`, so I just used the impl of Haskell and keep the name `hsSpecialChar`.