### PR TITLE
Add IdrisShowCore function

### DIFF
--- a/ftplugin/idris.vim
+++ b/ftplugin/idris.vim
@@ -138,6 +138,13 @@ function! IdrisShowDoc()
   call IWrite(ty)
 endfunction
 
+function! IdrisShowCore()
+  w
+  let word = expand("<cword>")
+  let ty = s:IdrisCommand(":core", word)
+  call IWrite(ty)
+endfunction
+
 function! IdrisProofSearch(hint)
   let view = winsaveview()
   w
@@ -326,6 +333,7 @@ nnoremap <buffer> <silent> <LocalLeader>w 0:call IdrisMakeWith()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>mc :call IdrisMakeCase()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>i 0:call IdrisResponseWin()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>h :call IdrisShowDoc()<ENTER>
+nnoremap <buffer> <silent> <LocalLeader>cr :call IdrisShowCore()<ENTER>
 
 menu Idris.Reload <LocalLeader>r
 menu Idris.Show\ Type <LocalLeader>t


### PR DESCRIPTION
David Christiansen [has recently demonstrated](https://groups.google.com/d/msg/idris-lang/FmvR3iny-gI/6sNlJwIFBgAJ) that the "show core" function can come in handy even when debugging rather simple issues. The following patch adds this capability to idris-vim, mapping it to the `<LocalLeader>cr` binding.

The other functions don't seem to be consistent in their use of `expand("<cword>")` as opposed to the `s:currentQueryObject()` helper function. I use the former, adapted from `IdrisShowDoc`.